### PR TITLE
Use UTF-8

### DIFF
--- a/mod.gradle
+++ b/mod.gradle
@@ -442,3 +442,18 @@ if (hasMixin() && System.getProperty("idea.sync.active") == "true") {
         }
     }
 }
+
+// Use UTF-8
+afterEvaluate {
+    tasks.withType(JavaCompile).configureEach {
+        options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Test).configureEach {
+        defaultCharacterEncoding = 'UTF-8'
+    }
+
+    tasks.withType(Javadoc).configureEach {
+        options.encoding = 'UTF-8'
+    }
+}


### PR DESCRIPTION
This explicitly specifies utf8 for compilation, tests and javadoc. See https://github.com/MinecraftForge/MinecraftForge/pull/8486